### PR TITLE
Add Shapely polygon collisions to linked-edges

### DIFF
--- a/board.py
+++ b/board.py
@@ -1,6 +1,8 @@
 from boardObjects import Marker, Qix, Sparx
 import pygame
 import copy
+import shapely
+from shapely import geometry
 
 DIRECTION_UPWARDS = (0, -1)
 DIRECTION_DOWNWARDS = (0, 1)
@@ -53,6 +55,7 @@ class Board():
         self.entities = []          # Contains all boardObjects in play
         self.firstEdgeBuffer = None
         self.edgesBuffer = None   # Contains a linked list reference on the current push
+        # self.playableAreaPolygon = None # Contains Polygon object representing player's non-push movable area. Polygon is useful for calculating area and determining 'insideness' for collisions
 
         initialPoints = [(36,6), (36,94), (124, 94), (124,6)]
 
@@ -66,6 +69,8 @@ class Board():
         pygame.display.init()
         self.mysurface = pygame.display.set_mode((1280, 800), pygame.RESIZABLE)
         self.resized = pygame.transform.scale(self.mysurface, (160, 100))
+        
+        self.playableAreaPolygon = self.remakePlayableArea()
 
     def gameStart(self, level):
         
@@ -229,3 +234,18 @@ class Board():
     def updateLocations(self):
 
         return
+
+    def remakePlayableArea(self):  # Happens when an incursion is finished, to induct the incursion shape into the playable area
+        
+        iterator = self.firstEdge.next
+        shapeList = []
+
+        while True:
+            if iterator == self.firstEdge:
+                shapeList.append(iterator.end)
+                break
+            shapeList.append(iterator.end)
+            iterator = iterator.next
+        
+        shape = shapely.geometry.Polygon(shapeList)
+        return shape

--- a/board.py
+++ b/board.py
@@ -56,8 +56,10 @@ class Board():
         self.firstEdgeBuffer = None
         self.edgesBuffer = None   # Contains a linked list reference on the current push
         # self.playableAreaPolygon = None # Contains Polygon object representing player's non-push movable area. Polygon is useful for calculating area and determining 'insideness' for collisions
+        # self.startingAreaPolygon = None # Used to measure captured area
 
         initialPoints = [(36,6), (36,94), (124, 94), (124,6)]
+        self.startingAreaPolygon = shapely.geometry.Polygon(initialPoints)
 
         # Initialise four corners
         self.firstEdge = Edge(initialPoints[0], initialPoints[1])

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from pygame.locals import *
 import pygame.event;
 import sys
 import math
+import shapely
 
 from board import Board, DIRECTION_DOWNWARDS, DIRECTION_LEFTWARDS, DIRECTION_RIGHTWARDS, DIRECTION_UPWARDS, Edge
 from boardObjects import Marker
@@ -97,7 +98,7 @@ def main():
                     board.edgesBuffer = edge.next
                     previousMoveVector = moveVector
 
-            elif moveVector != (0,0):
+            elif moveVector != (0,0) and (board.playableAreaPolygon.contains(shapely.geometry.Point(player.x + moveVector[0], player.y + moveVector[1])) or board.playableAreaPolygon.touches(shapely.geometry.Point(player.x + moveVector[0], player.y + moveVector[1]))): # Probably refactor this LOL (put this in a method or something)
                 player.updateLocation(player.x + moveVector[0], player.y + moveVector[1])
                 touchingEdge = currentEdge(player, board)
                 
@@ -186,6 +187,8 @@ def main():
                     board.getMarker().setIsPushing(False)
                     board.firstEdgeBuffer = None
                     board.edgesBuffer = None
+                    board.playableAreaPolygon = board.remakePlayableArea()
+
 
         board.draw() # draw all objects
 

--- a/main.py
+++ b/main.py
@@ -188,6 +188,7 @@ def main():
                     board.firstEdgeBuffer = None
                     board.edgesBuffer = None
                     board.playableAreaPolygon = board.remakePlayableArea()
+                    print("Captured Area: ", int(round(100 - 100 * board.playableAreaPolygon.area / board.startingAreaPolygon.area)), "%")
 
 
         board.draw() # draw all objects


### PR DESCRIPTION
This PR introduces logic to the linked-edges branch to assist in detecting and managing collisions within the playable area.

Note: This change adds a dependency for the shapely package.